### PR TITLE
Fixed is_owner_check

### DIFF
--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -20,7 +20,7 @@ except:
     settings = {"OWNER" : False, "ADMIN_ROLE" : False, "MOD_ROLE" : False}
 
 def is_owner_check(ctx):
-    return ctx.message.author.id == owner
+    return ctx.message.author.id == settings["OWNER"]
 
 def is_owner():
     return commands.check(is_owner_check)


### PR DESCRIPTION
Was originally checking against a (as far as I can tell) undefined variable, and wasn't working for me. Using the owner id from the settings dictionary fixed my problem